### PR TITLE
fix: user result api 호출 시 mbti 순서가 보장되어있지 않아 에러 발생 픽스

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001488",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
-      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
       "funding": [
         {
           "type": "opencollective",
@@ -573,9 +573,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -591,9 +591,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001488",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
-      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ=="
+      "version": "1.0.30001524",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
+      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA=="
     },
     "client-only": {
       "version": "0.0.1",

--- a/pages/questions/index.js
+++ b/pages/questions/index.js
@@ -85,7 +85,7 @@ const ProgressBar = ({ currentNumber }) => {
 
 export default function Questions() {
   const [currentNumber, setCurrentNumber] = useState(0);
-  const [mbtiList, setMbtiList] = useState([]);
+  const [mbtiList, setMbtiList] = useState({ EI: [], NS: [], FT: [], PJ: [] });
   const [questionsData, setQuestionsData] = useState([]);  // 질문 데이터를 저장할 상태 변수
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -120,8 +120,14 @@ export default function Questions() {
   const nextQuestion = (choiceNumber) => { 
     const isLastQuestion = currentNumber === questionsData.data.total - 1;
     const selectedChoice = questionsData.data.list[currentNumber]?.questionSub[choiceNumber].type;
-    setMbtiList((prevList) => [...prevList, selectedChoice]);
-  
+    
+    setMbtiList((prevState) => {
+      return {
+        ...prevState,
+        [questionsData.data.list[currentNumber].type]: [...(prevState[questionsData.data.list[currentNumber].type]), selectedChoice],
+      };
+    });
+
     if (isLastQuestion) {
       showResultPage(choiceNumber); 
     } else {
@@ -131,25 +137,47 @@ export default function Questions() {
   
   const showResultPage = (choiceNumber) => { 
     const lastChoiceType = questionsData.data.list[currentNumber].questionSub[choiceNumber].type;
-    const updatedMbtiList = [...mbtiList, lastChoiceType];
-  
+    const updatedMbtiList = {
+      ...mbtiList,
+      [questionsData.data.list[currentNumber].type]: [...(mbtiList[questionsData.data.list[currentNumber].type]), lastChoiceType],
+    };
+
     setMbtiList(updatedMbtiList);
 
-    const groupedMbti = [];
-    for (let i = 0; i < updatedMbtiList.length; i += 3) {
-      groupedMbti.push(updatedMbtiList.slice(i, i + 3));
+    const mbtiCount = {
+      "EI": {
+        'E': 0,
+        'I': 0,
+      },
+      "NS": {
+        'N': 0,
+        'S': 0,
+      },
+      "FT": {
+        'F': 0,
+        'T': 0,
+      },
+      "PJ": {
+        'P': 0,
+        'J': 0,
+      },
     }
+    
+
+    for (const key of Object.keys(mbtiList)){
+      for (const value of mbtiList[key]) {
+          mbtiCount[key][value] += 1
+      } 
+    }
+
+    let mbtiQueryString = '';
+
+    for (const value in mbtiCount) {
+      const type = mbtiCount[value];
+      const resultType = Object.keys(type).reduce((a, b) => type[a] > type[b] ? a : b);
+      mbtiQueryString += resultType;
+    }  
   
-    const mbtiCounts = {};
-    updatedMbtiList.forEach((mbti) => {
-      mbtiCounts[mbti] = (mbtiCounts[mbti] || 0) + 1;
-    });
-  
-    const mostFrequentMbti = Object.keys(mbtiCounts).sort((a, b) => mbtiCounts[b] - mbtiCounts[a]).slice(0, 4);
-  
-    const resultMbtiList = mostFrequentMbti;
-  
-    const mbtiQueryString = resultMbtiList.map(mbti => `${mbti}`).join('');
     router.push(`/results?mbti=${mbtiQueryString}`);
   };
   


### PR DESCRIPTION
### 이슈
기존 question 선택후 MBTI 성향을 list 담아 보관후 마지막 result 시 많이 나온 셩향으로 간추려 mbti를 queryString에 담을려고 하니 순서가 보장되어 있지 않은 list 라서 이상한 mbti가 나옴 
ex) PNFI

### 해결
question 선택후 성향을 list에 보관하는게 아닌 object에 보관함으로서 mbti를 완성할 때 순서가 보장되어 있음으로 에러가 발생하지 않음