### PR TITLE
fix: 클릭시 visit count 증가 제거

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -22,8 +22,6 @@ export default function Home() {
   const handleClick = () => {
     setIsClicked(true);
 
-    setVisitorCount(prevCount => prevCount + 1);
-   
     setTimeout(() => {
       window.location.href = '/questions';
     }, 300); //0.3s뒤 페이지이동


### PR DESCRIPTION
### 이슈
서비스를 끝까지 완료 해야 카운트가 올라가야 하지만 클릭시 + 1 되버려서 참여하지 않더라도 1이 되고 다시 뒤로 갔을땐 참여하지 않은 유저다보니 다시 -1 이 되는 조금 어색한 상황이 됨

### 해결
서비스 이용 완료시 backend api 에서 제공하는 count 수로만 메인 표시